### PR TITLE
Fix the links of the previous PR to point to the Commons docs instead of my fork links

### DIFF
--- a/android/build-variants/Build-Variants.md
+++ b/android/build-variants/Build-Variants.md
@@ -29,7 +29,7 @@ The four build variants:
 
 `prodRelease`: This is the release version of the app which connects to the production server. This cannot be used for debugging the app. You would have to sign this version of the app using your signing keys.
 
-For information on how to change `build variants`, [this page can be referred](https://github.com/Glitch101/documentation/blob/master/android/build-variants/Changing-Build-Variants.md).
+For information on how to change `build variants`, [this page can be referred](https://github.com/commons-app/documentation/blob/master/android/build-variants/Changing-Build-Variants.md).
 
 ### Links to official android documentation
 Build types - https://developer.android.com/studio/build/build-variants#build-types

--- a/android/build-variants/Build-Variants.md
+++ b/android/build-variants/Build-Variants.md
@@ -29,7 +29,7 @@ The four build variants:
 
 `prodRelease`: This is the release version of the app which connects to the production server. This cannot be used for debugging the app. You would have to sign this version of the app using your signing keys.
 
-For information on how to change `build variants`, [this page can be referred](https://github.com/commons-app/documentation/blob/master/android/build-variants/Changing-Build-Variants.md).
+For information on how to change `build variants`, [this page can be referred](Changing-Build-Variants.md).
 
 ### Links to official android documentation
 Build types - https://developer.android.com/studio/build/build-variants#build-types

--- a/android/build-variants/Changing-Build-Variants.md
+++ b/android/build-variants/Changing-Build-Variants.md
@@ -1,6 +1,6 @@
 ## Changing build variants of the Commons android project
 This page contains the instructions for changing the build variants of the Commons project in Android Studio.
-Information regrading different build variants of the Commons project can be found [here](https://github.com/Glitch101/documentation/blob/master/android/build-variants/Build-Variants.md)
+Information regrading different build variants of the Commons project can be found [here](https://github.com/commons-app/documentation/blob/master/android/build-variants/Build-Variants.md)
 
 Step 1: Go to `Build` on the toolbar
 

--- a/android/build-variants/Changing-Build-Variants.md
+++ b/android/build-variants/Changing-Build-Variants.md
@@ -1,6 +1,6 @@
 ## Changing build variants of the Commons android project
 This page contains the instructions for changing the build variants of the Commons project in Android Studio.
-Information regrading different build variants of the Commons project can be found [here](https://github.com/commons-app/documentation/blob/master/android/build-variants/Build-Variants.md)
+Information regrading different build variants of the Commons project can be found [here](Build-Variants.md)
 
 Step 1: Go to `Build` on the toolbar
 


### PR DESCRIPTION
In the [previous PR](https://github.com/commons-app/documentation/pull/1), the links were pointing to my fork. This PR fixes this so that they point to the main docs repo of Commons.
Thanks to @maskaravivek for pointing this out :)