### PR TITLE
Code-style: stop recommending Butterknife

### DIFF
--- a/android/Code-style.md
+++ b/android/Code-style.md
@@ -77,7 +77,7 @@ Note:
 
 ### Butterknife
 
-Contributors have the option of using [butterknife](https://github.com/JakeWharton/butterknife) for their view bindings. We recommend doing so if you can.
+As mentioned above, contributors have the option of using [butterknife](https://github.com/JakeWharton/butterknife) for their view bindings for existing Java classes.
 
 #### Usage
 


### PR DESCRIPTION
We're not recommending Butterknife anymore for the view bindings. So, stop
recommending it in the code style.